### PR TITLE
minor change to ensure vignettes are built

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ represent election results in ternary diagrams.
 To install from GitHub:
 
 ``` r
-devtools::install_github("aeggers/votevizr")
+devtools::install_github("aeggers/votevizr", build_vignettes = TRUE)
 ```
 
 ## Example


### PR DESCRIPTION
In my system the vignettes are not built if I do not explicitly specify that in the `install_github` command. Minor change in the README, but ensures this doesn't happen with others.